### PR TITLE
[Fix] to how dates are calculated for displaying

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -190,7 +190,7 @@ server.get("/events", async (req, res, next) => {
     fetchedEvents = await prisma.event.findMany({
         where: {
             name: { contains: requestQueries.search, mode: "insensitive" },
-            end_time: { gte: new Date(Date.now()) },
+            end_time: { gte: new Date((new Date(Date.now())).getTime() - ((new Date()).getTimezoneOffset() * 60 * 1000)) },
         },
         include: { organizer: { include: { profile: true } }, profiles_saved: true },
     });

--- a/frontend/src/components/CreatePage.jsx
+++ b/frontend/src/components/CreatePage.jsx
@@ -64,9 +64,6 @@ const CreatePage = () => {
             description: formInputs.descProps.value,
             category: formInputs.catProps.value,
         };
-        if (newEvent.price === 0) {
-            newEvent[price] = "Free"
-        }
         createEventMutation.mutate(newEvent);
     };
 


### PR DESCRIPTION
### Description
* Fix small bug where server was not taking into account time zone when calculating which events to show

### Test Plan
> You can see events happening the same day later (Fun Day at 5:40pm) in the list. In the past it would not show because of the timezone
<img width="1800" height="1037" alt="Screenshot 2025-07-24 at 16 58 06" src="https://github.com/user-attachments/assets/c2d41aee-f884-48a2-a06a-1627f38c4c57" />
